### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Automatically sets `opam` environmental variables
 Using [Fisherman][fisher]:
 
 ```
-fisher install lwolfsonkin/fish-plugin-opam
+fisher add lwolfsonkin/fish-plugin-opam
 ```
 
 ## Potential Issues

--- a/conf.d/opam.fish
+++ b/conf.d/opam.fish
@@ -4,6 +4,7 @@ if command -s opam > /dev/null
     set -l switch (opam switch show)
     set -gx CAML_LD_LIBRARY_PATH "$HOME/.opam/$switch/lib/stublibs:/usr/local/lib/ocaml/stublibs";
     set -gx OPAMUTF8MSGS "1";
+    set -ge MANPATH
     set -gx MANPATH "$HOME/.opam/$switch/man":(manpath);
     set -gx PERL5LIB "$HOME/.opam/$switch/lib/perl5";
     set -gx OCAML_TOPLEVEL_PATH "$HOME/.opam/$switch/lib/toplevel";

--- a/conf.d/opam.fish
+++ b/conf.d/opam.fish
@@ -1,12 +1,13 @@
 # set the user installation path
 
 if command -s opam > /dev/null
-    set -gx CAML_LD_LIBRARY_PATH "$HOME/.opam/system/lib/stublibs:/usr/local/lib/ocaml/stublibs";
+    set -l switch (opam switch show)
+    set -gx CAML_LD_LIBRARY_PATH "$HOME/.opam/$switch/lib/stublibs:/usr/local/lib/ocaml/stublibs";
     set -gx OPAMUTF8MSGS "1";
-    set -gx MANPATH "$HOME/.opam/system/man":(manpath);
-    set -gx PERL5LIB "$HOME/.opam/system/lib/perl5";
-    set -gx OCAML_TOPLEVEL_PATH "$HOME/.opam/system/lib/toplevel";
-    set -gx PATH "$HOME/.opam/system/bin" $PATH;
+    set -gx MANPATH "$HOME/.opam/$switch/man":(manpath);
+    set -gx PERL5LIB "$HOME/.opam/$switch/lib/perl5";
+    set -gx OCAML_TOPLEVEL_PATH "$HOME/.opam/$switch/lib/toplevel";
+    set -gx PATH "$HOME/.opam/$switch/bin" $PATH;
 else
     function opam -d "https://opam.ocaml.org/doc/Install.html"
         echo "Install https://opam.ocaml.org/doc/Install.html to use this plugin." > /dev/stderr


### PR DESCRIPTION
Hi! Thanks for open-sourcing this useful :fish: plugin. Please consider following fixes:

- minor README change to reflect changes in fisher.
- using current switch (as seen by opam) instead of system one, which many not be present. If no switches are installed at all, opam will display a corresponding warning upon interactive shell launch. This is a most important change in this patch, because using `system` switch may simply not work at all for some users, and is not flexible.
- `manpath` utility no longer gives warning when installing plugin with fisher. Moreover, consecutive fisher runs will no longer keep prepending variable with OCaml's man path (yay inplace mutation). While this is not a big issue, resetting variable just before assigning is a cleaner approach IMO. There's also downside: resetting global MANPATH may conflict with user configuration and other plugins.